### PR TITLE
hotfix/tokenId: fixed filtering by tokenId

### DIFF
--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -281,6 +281,7 @@ export class OrdersService {
     }
 
     if (query.tokenId) {
+      // @TODO there is no filtering by tokenId for ERC721_BUNDLE orders supposedly because of array of arrays
       const queryMake = `make->'assetType'->>'tokenId' = :tokenId`;
       const queryTake = `take->'assetType'->>'tokenId' = :tokenId`;
       const queryForBoth = `((${queryMake}) OR (${queryTake}))`;


### PR DESCRIPTION
fixed filtering by tokenId.
the problem was that filtering by tokenId would not find anything.
this fix has been requested by @edmoiseenkov 