### PR TITLE
fix(assetClass-filters): fix assetClass and tokenIds query

### DIFF
--- a/src/modules/orders/order.dto.ts
+++ b/src/modules/orders/order.dto.ts
@@ -219,11 +219,11 @@ export class QueryDto {
   side: number;
 
   @ApiProperty({
-    example: 'ERC721_BUNDLE',
+    example: 'ERC721,ERC721_BUNDLE',
     description: 'Asset class of the order. e.g. ERC721, ERC721_BUNDLE',
     required: false,
   })
-  @IsEnum(AssetClass)
+  @IsString()
   @IsOptional()
   assetClass: AssetClass;
 

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -371,11 +371,11 @@ export class OrdersService {
     }
 
     if (query.assetClass) {
-      const queryMake = `make->'assetType'->'assetClass' = :assetClass`;
-      const queryTake = `take->'assetType'->'assetClass' = :assetClass`;
+      const queryMake = `make->'assetType'->>'assetClass' IN (:...assetClass)`;
+      const queryTake = `take->'assetType'->>'assetClass' IN (:...assetClass)`;
       const queryForBoth = `((${queryMake}) OR (${queryTake}))`;
       queryBuilder.andWhere(queryForBoth, {
-        assetClass: `"${query.assetClass}"`,
+        assetClass: query.assetClass.replace(/\s/g, '').split(','),
       });
     }
 
@@ -549,11 +549,10 @@ export class OrdersService {
     }
 
     if (query.assetClass) {
-      const queryMake = `make->'assetType'->'assetClass' = :assetClass`;
-      const queryTake = `take->'assetType'->'assetClass' = :assetClass`;
-      const queryForBoth = `((${queryMake}) OR (${queryTake}))`;
-      queryBuilder.andWhere(queryForBoth, {
-        assetClass: `"${query.assetClass}"`,
+      const queryMake = `make->'assetType'->>'assetClass' IN (:...assetClass)`;
+      console.log(query.assetClass.replace(/\s/g, '').split(','));
+      queryBuilder.andWhere(queryMake, {
+        assetClass: query.assetClass.replace(/\s/g, '').split(','),
       });
     }
 
@@ -571,8 +570,8 @@ export class OrdersService {
 
     if (query.tokenIds) {
       // @TODO there is no filtering by tokenId for ERC721_BUNDLE orders supposedly because of array of arrays
-      const queryMake = `make->'assetType'->>'tokenId' IN (:tokenIds)`;
-      const queryTake = `take->'assetType'->>'tokenId' IN (:tokenIds)`;
+      const queryMake = `make->'assetType'->>'tokenId' IN (:...tokenIds)`;
+      const queryTake = `take->'assetType'->>'tokenId' IN (:...tokenIds)`;
       const queryForBoth = `((${queryMake}) OR (${queryTake}))`;
       queryBuilder.andWhere(queryForBoth, {
         tokenIds: query.tokenIds.replace(/\s/g, '').split(','),


### PR DESCRIPTION
This PR changes the OrdersQuery dto in a way that assetClass filters allows you to pass multiple filters. This is necessary because you must be able to filter by different combinations of assets.

Also fixed a bug with the tokenIds query where the array wasn't destructured.

Shortcut link: 
https://app.shortcut.com/universexyz/story/2133/fix-filtering-in-browse-marketplace