### PR TITLE
Filtered get active listings endpoint not to return already expired ones

### DIFF
--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -87,6 +87,7 @@ export class OrdersService {
     }
 
     const order = this.convertToOrder(data);
+    const utcTimestamp = Utils.getUtcTimestamp();
 
     // Check if order for the nft already exists
     if (order.side === OrderSide.SELL) {
@@ -94,6 +95,12 @@ export class OrdersService {
         .createQueryBuilder('order')
         .where('side = :side', { side: OrderSide.SELL })
         .where('status = :status', { status: OrderStatus.CREATED })
+        .andWhere(`(order.start = 0 OR order.start < :start)`, {
+          start: utcTimestamp,
+        })
+        .andWhere(`(order.end = 0 OR :end < order.end )`, {
+          end: utcTimestamp,
+        })
         .andWhere(`make->'assetType'->>'tokenId' = :tokenId`, {
           tokenId: order.make.assetType.tokenId,
         })
@@ -804,10 +811,17 @@ export class OrdersService {
    * @returns order
    */
   public async queryOne(contract: string, tokenId: string, maker = '') {
-    const queryBuilder = this.orderRepository.createQueryBuilder();
+    const utcTimestamp = Utils.getUtcTimestamp();
+    const queryBuilder = this.orderRepository.createQueryBuilder('order');
     queryBuilder.where('status = :status', { status: OrderStatus.CREATED });
 
     queryBuilder.andWhere('side = :side', { side: OrderSide.SELL });
+    queryBuilder.andWhere(`(order.start = 0 OR order.start < :start)`, {
+      start: utcTimestamp,
+    });
+    queryBuilder.andWhere(`(order.end = 0 OR :end < order.end )`, {
+      end: utcTimestamp,
+    });
 
     if (maker) {
       queryBuilder.andWhere('maker = :maker', { maker: maker.toLowerCase() });


### PR DESCRIPTION
## Description
Added checks for already expired listings on the create order an get active listings method.

## Related Issue
- https://app.shortcut.com/universexyz/story/3190/expired-listing-bug

## How Has This Been Tested?
- create a listing
- wait for it to expire
- verify listings + history tab
- verify that there is no `buy for` button