### PR TITLE
Retrieve splits data from database rather than prepare endpoint

### DIFF
--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -292,10 +292,10 @@ export class OrdersService {
       start: leftOrder.start,
       end: leftOrder.end,
       data: {
-        dataType: prepareDto.revenueSplits?.length
+        dataType: leftOrder.data.revenueSplits?.length
           ? constants.ORDER_DATA
           : constants.DATA_TYPE_0X,
-        revenueSplits: prepareDto.revenueSplits,
+        revenueSplits: leftOrder.data.revenueSplits,
       },
     });
     return rightOrder;


### PR DESCRIPTION
Revenue splits should not be coming from the prepare endpoint

They are stored into the database upon order creation and rather should come from the database