### PR TITLE
sc-4097-mongo: Fix doubled listings on prod

### DIFF
--- a/src/modules/orders/mongo-orders.service.ts
+++ b/src/modules/orders/mongo-orders.service.ts
@@ -109,12 +109,7 @@ export class OrdersService {
             contract: order.make.assetType.contract.toLowerCase(),
           },
         },
-        $and: [
-          // {
-          //   $or: [{ start: { $lt: utcTimestamp } }, { start: 0 }],
-          // },
-          { $or: [{ end: { $gt: utcTimestamp } }, { end: 0 }] },
-        ],
+        $and: [{ $or: [{ end: { $gt: utcTimestamp } }, { end: 0 }] }],
       });
 
       if (existingOrder) {


### PR DESCRIPTION
repeating updates in this story https://app.shortcut.com/universexyz/story/4097/fix-doubled-listings-on-prod
to the mongo-orders.service.ts file
@vikinatora 